### PR TITLE
Add bulk user insert endpoint

### DIFF
--- a/UniwayBackend/Controllers/UserController.cs
+++ b/UniwayBackend/Controllers/UserController.cs
@@ -6,6 +6,7 @@ using UniwayBackend.Models.Entities;
 using UniwayBackend.Models.Payloads.Base.Response;
 using UniwayBackend.Models.Payloads.Core.Request;
 using UniwayBackend.Models.Payloads.Core.Response;
+using UniwayBackend.Models.Payloads.Core.Request.Users;
 using UniwayBackend.Services.interfaces;
 
 namespace UniwayBackend.Controllers
@@ -23,6 +24,27 @@ namespace UniwayBackend.Controllers
             _service = service;
             _mapper = mapper;
             _logger = logger;
+        }
+
+        [HttpPost("SaveAll")]
+        public async Task<ActionResult<MessageResponse<UserResponse>>> SaveAll([FromBody] List<UserInsertRequest> users)
+        {
+            MessageResponse<UserResponse> response;
+            try
+            {
+                _logger.LogInformation(MethodBase.GetCurrentMethod().Name);
+
+                var result = await _service.SaveAll(users);
+
+                response = _mapper.Map<MessageResponse<User>, MessageResponse<UserResponse>>(result);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex.Message);
+                response = new MessageResponseBuilder<UserResponse>()
+                    .Code(500).Message(ex.Message).Build();
+            }
+            return StatusCode(response.Code, response);
         }
 
         [HttpPut("EditProfile")]

--- a/UniwayBackend/Models/Payloads/Core/Request/Users/UserInsertRequest.cs
+++ b/UniwayBackend/Models/Payloads/Core/Request/Users/UserInsertRequest.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
+namespace UniwayBackend.Models.Payloads.Core.Request.Users
+{
+    public class UserInsertRequest
+    {
+        [DefaultValue("xxxx@gmail.com")]
+        [Required(ErrorMessage = "El campo Email es obligatorio.")]
+        [EmailAddress(ErrorMessage = "El campo Email debe ser una dirección de correo electrónico válida.")]
+        public required string Email { get; set; }
+
+        [DefaultValue("xxxx")]
+        [Required(ErrorMessage = "El campo Password es obligatorio.")]
+        [MinLength(4, ErrorMessage = "La longitud mínima de la contraseña es de 4 caracteres.")]
+        public required string Password { get; set; }
+
+        [DefaultValue("2")]
+        [Required(ErrorMessage = "El campo RoleId es obligatorio.")]
+        public required short RoleId { get; set; }
+    }
+}

--- a/UniwayBackend/Services/implements/UserService.cs
+++ b/UniwayBackend/Services/implements/UserService.cs
@@ -1,9 +1,11 @@
 ﻿using Azure.Core;
 using System.Reflection;
+using UniwayBackend.Config;
 using UniwayBackend.Factories;
 using UniwayBackend.Models.Entities;
 using UniwayBackend.Models.Payloads.Base.Response;
 using UniwayBackend.Models.Payloads.Core.Request;
+using UniwayBackend.Models.Payloads.Core.Request.Users;
 using UniwayBackend.Repositories.Core.Interfaces;
 using UniwayBackend.Services.interfaces;
 
@@ -86,6 +88,36 @@ namespace UniwayBackend.Services.implements
                 if (user is null) return _utilitaries.setResponseBaseForInternalServerError();
 
                 return _utilitaries.setResponseBaseForObject(user);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex.Message);
+                response = _utilitaries.setResponseBaseForException(ex);
+            }
+            return response;
+        }
+
+        public async Task<MessageResponse<User>> SaveAll(List<UserInsertRequest> users)
+        {
+            MessageResponse<User> response;
+            try
+            {
+                _logger.LogInformation(MethodBase.GetCurrentMethod().Name);
+
+                List<User> entities = users.Select(x => new User
+                {
+                    Id = Guid.NewGuid(),
+                    RoleId = x.RoleId,
+                    Email = x.Email,
+                    Password = x.Password,
+                    Enabled = Constants.State.ACTIVE_BOOL,
+                    CreatedOn = DateTime.UtcNow,
+                    UpdatedOn = DateTime.UtcNow
+                }).ToList();
+
+                var result = await _repository.InsertAll(entities);
+
+                response = _utilitaries.setResponseBaseForList(result);
             }
             catch (Exception ex)
             {

--- a/UniwayBackend/Services/interfaces/IUserService.cs
+++ b/UniwayBackend/Services/interfaces/IUserService.cs
@@ -1,6 +1,7 @@
 ﻿using UniwayBackend.Models.Entities;
 using UniwayBackend.Models.Payloads.Base.Response;
 using UniwayBackend.Models.Payloads.Core.Request;
+using UniwayBackend.Models.Payloads.Core.Request.Users;
 
 namespace UniwayBackend.Services.interfaces
 {
@@ -10,5 +11,6 @@ namespace UniwayBackend.Services.interfaces
         Task<MessageResponse<User>> GetById(Guid Id);
         Task<MessageResponse<User>> Update(ProfileRequest request);
         Task<MessageResponse<User>> Delete(Guid userId, int roleId);
+        Task<MessageResponse<User>> SaveAll(List<UserInsertRequest> users);
     }
 }


### PR DESCRIPTION
## Summary
- allow bulk creation of users via new `SaveAll` endpoint
- introduce `UserInsertRequest` DTO and service support for list inserts

## Testing
- `dotnet build --no-restore`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6898ff9e94848325aca4c748a15081dc